### PR TITLE
Py3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ RUN apt-get update && \
         libdb++-dev \
         libdb-dev \
         lsb-release \
-        python-dev \
-        python-pip \
+        python3-dev \
+        python3-pip \
+        python3-wheel \
         software-properties-common
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 5E6DA83306132997
@@ -23,7 +24,6 @@ RUN apt-get update && \
     zeroc-ice-all-runtime \
     zeroc-ice-all-dev
 
-RUN pip install wheel
 RUN mkdir /dist
 ADD build.sh /
 CMD ["/build.sh"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Ubuntu 16.04 Zeroc Ice Python Builder
-=====================================
+Ubuntu 16.04 Zeroc Ice Python 3 Builder
+=======================================
 
 Builds Zeroc Ice wheel for Ubuntu 16.04.
 

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 set -eu
 
 ICE_VERSION=${1:-"3.6.5"}
-pip download "zeroc-ice==$ICE_VERSION"
+pip3 download "zeroc-ice==$ICE_VERSION"
 tar -zxf "zeroc-ice-$ICE_VERSION.tar.gz"
 cd "zeroc-ice-$ICE_VERSION"
-python setup.py bdist_wheel
+python3 setup.py bdist_wheel
 cp dist/* /dist/

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-ICE_VERSION=${1:-"3.6.4"}
+ICE_VERSION=${1:-"3.6.5"}
 pip download "zeroc-ice==$ICE_VERSION"
 tar -zxf "zeroc-ice-$ICE_VERSION.tar.gz"
 cd "zeroc-ice-$ICE_VERSION"


### PR DESCRIPTION
Switch to Python3 and upgrade ice version to 3.6.5

Testing:
```
docker pull ubuntu:16.04
```
```
docker build -t builder .
docker run --rm -v $PWD/dist:/dist builder
```
```
docker run -it --rm -v $PWD/dist:/dist:ro ubuntu:16.04
apt-get update
apt-get install python3
apt-get install python3-venv
python3 -mvenv venv
venv/bin/pip install /dist/zeroc_ice-3.6.5-cp35-cp35m-linux_x86_64.whl
venv/bin/python -c 'import Ice; print(Ice.stringVersion())'
```

Should also work without a virtualenv

To be used in omero-install

Proposed tag: 0.2.0